### PR TITLE
Rename to Attraction Island

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -25,7 +25,7 @@ export function Layout() {
           <div className="flex h-16 items-center justify-between">
             <Link to="/" className="flex items-center gap-2">
               <Heart className="h-6 w-6 text-pink-500" />
-              <span className="text-xl font-bold">Love Island Storyboard</span>
+              <span className="text-xl font-bold">Attraction Island Storyboard</span>
             </Link>
             
             <nav className="flex items-center gap-6">

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -25,8 +25,8 @@ export const Route = createRootRoute({
         content: 'width=device-width, initial-scale=1',
       },
       ...seo({
-        title: 'Love Island Storyboard - Production Tool',
-        description: 'Storyboarding and production tool for Love Island episodes',
+        title: 'Attraction Island Storyboard - Production Tool',
+        description: 'Storyboarding and production tool for Attraction Island episodes',
       }),
     ],
     links: [

--- a/src/routes/episodes.index.tsx
+++ b/src/routes/episodes.index.tsx
@@ -18,7 +18,7 @@ function EpisodesPage() {
       id: '1',
       number: 1,
       title: 'Dustin Intro',
-      description: 'Meet Dustin, our first contestant arriving at the Love Island villa.',
+      description: 'Meet Dustin, our first contestant arriving at the Attraction Island villa.',
       scenes: [],
       status: 'completed',
       airDate: '2024-01-15',

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -26,9 +26,9 @@ function Home() {
   return (
     <div className="space-y-8">
       <div>
-        <h1 className="text-4xl font-bold">Love Island Storyboard</h1>
+        <h1 className="text-4xl font-bold">Attraction Island Storyboard</h1>
         <p className="text-muted-foreground mt-2">
-          Production management tool for creating Love Island episodes
+          Production management tool for creating Attraction Island episodes
         </p>
       </div>
 


### PR DESCRIPTION
## Summary
- rename product references from Love Island to Attraction Island

## Testing
- `pnpm install`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_687c1deecee88323808fa53b429a31cd