### PR TITLE
Add fal.ai playground page with model options

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-dom": "^19.0.0",
     "remotion": "^4.0.324",
     "tailwind-merge": "^2.6.0",
+    "@fal-ai/client": "^1.6.0",
     "zod": "^3.24.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@fal-ai/client':
+        specifier: ^1.6.0
+        version: 1.6.0
       '@radix-ui/react-checkbox':
         specifier: ^1.3.2
         version: 1.3.2(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -891,6 +894,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@fal-ai/client@1.6.0':
+    resolution: {integrity: sha512-6KUWtIm7HRv/+62zlxXEOdtzB2axXU6tmv1ruJDt37NbsjrIfQiXf24CggytatPh2hqOOl1/z+nDzhDg8vd3qA==}
+    engines: {node: '>=18.0.0'}
+
   '@fastify/busboy@3.1.1':
     resolution: {integrity: sha512-5DGmA8FTdB2XbDeEwc/5ZXBl6UbBAyBOOLlPuBnZ/N1SwdH9Ii+cOX3tBROlDgcTXxjOYnLMVoKk9+FXAw0CJw==}
 
@@ -940,6 +947,10 @@ packages:
     resolution: {integrity: sha512-llMXd39jtP0HpQLVI37Bf1m2ADlEb35GYSh1SDSLsBhR+5iCxiNGlT31yqbNtVHygHAtMy6dWFERpU2JgufhPg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@msgpack/msgpack@3.1.2':
+    resolution: {integrity: sha512-JEW4DEtBzfe8HvUYecLU9e6+XJnKDlUAIve8FvPzF3Kzs6Xo/KuZkZJsDH0wJXl/qEZbeeE7edxDNY3kMs39hQ==}
+    engines: {node: '>= 18'}
 
   '@netlify/binary-info@1.0.0':
     resolution: {integrity: sha512-4wMPu9iN3/HL97QblBsBay3E1etIciR84izI3U+4iALY+JHCrI+a2jO0qbAZ/nxKoegypYEaiiqWXylm+/zfrw==}
@@ -2734,6 +2745,10 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
+  eventsource-parser@1.1.2:
+    resolution: {integrity: sha512-v0eOBUbiaFojBu2s2NPBfYUoRR9GjcDNvCXVaqEf5vVfpIAh9f8RCo4vXTP8c63QRKCFwoLpMpTdPwwhEKVgzA==}
+    engines: {node: '>=14.18'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -3892,6 +3907,9 @@ packages:
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  robot3@0.4.1:
+    resolution: {integrity: sha512-hzjy826lrxzx8eRgv80idkf8ua1JAepRc9Efdtj03N3KNJuznQCPlyCJ7gnUmDFwZCLQjxy567mQVKmdv2BsXQ==}
 
   rollup-plugin-visualizer@6.0.3:
     resolution: {integrity: sha512-ZU41GwrkDcCpVoffviuM9Clwjy5fcUxlz0oMoTXTYsK+tcIFzbdacnrr2n8TXcHxbGKKXtOdjxM2HUS4HjkwIw==}
@@ -5184,6 +5202,12 @@ snapshots:
   '@esbuild/win32-x64@0.25.8':
     optional: true
 
+  '@fal-ai/client@1.6.0':
+    dependencies:
+      '@msgpack/msgpack': 3.1.2
+      eventsource-parser: 1.1.2
+      robot3: 0.4.1
+
   '@fastify/busboy@3.1.1': {}
 
   '@floating-ui/core@1.7.2':
@@ -5249,6 +5273,8 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  '@msgpack/msgpack@3.1.2': {}
 
   '@netlify/binary-info@1.0.0': {}
 
@@ -7392,6 +7418,8 @@ snapshots:
 
   events@3.3.0: {}
 
+  eventsource-parser@1.1.2: {}
+
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -8589,6 +8617,8 @@ snapshots:
       supports-preserve-symlinks-flag: 1.0.0
 
   reusify@1.1.0: {}
+
+  robot3@0.4.1: {}
 
   rollup-plugin-visualizer@6.0.3(rollup@4.45.1):
     dependencies:

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -4,8 +4,9 @@ import {
   Users, 
   MapPin, 
   Film, 
-  Clapperboard, 
+  Clapperboard,
   Settings,
+  Sparkles,
   Heart
 } from 'lucide-react'
 
@@ -14,6 +15,7 @@ const navigation = [
   { name: 'Locations', href: '/locations', icon: MapPin },
   { name: 'Episodes', href: '/episodes', icon: Film },
   { name: 'Storyboard', href: '/storyboard', icon: Clapperboard },
+  { name: 'fal.ai', href: '/fal', icon: Sparkles },
   { name: 'Settings', href: '/settings', icon: Settings },
 ]
 

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as StoryboardRouteImport } from './routes/storyboard'
 import { Route as SettingsRouteImport } from './routes/settings'
 import { Route as LocationsRouteImport } from './routes/locations'
+import { Route as FalRouteImport } from './routes/fal'
 import { Route as CharactersRouteImport } from './routes/characters'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as EpisodesIndexRouteImport } from './routes/episodes.index'
@@ -31,6 +32,11 @@ const SettingsRoute = SettingsRouteImport.update({
 const LocationsRoute = LocationsRouteImport.update({
   id: '/locations',
   path: '/locations',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const FalRoute = FalRouteImport.update({
+  id: '/fal',
+  path: '/fal',
   getParentRoute: () => rootRouteImport,
 } as any)
 const CharactersRoute = CharactersRouteImport.update({
@@ -62,6 +68,7 @@ const EpisodesEpisodeIdRoute = EpisodesEpisodeIdRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/characters': typeof CharactersRoute
+  '/fal': typeof FalRoute
   '/locations': typeof LocationsRoute
   '/settings': typeof SettingsRoute
   '/storyboard': typeof StoryboardRoute
@@ -72,6 +79,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/characters': typeof CharactersRoute
+  '/fal': typeof FalRoute
   '/locations': typeof LocationsRoute
   '/settings': typeof SettingsRoute
   '/storyboard': typeof StoryboardRoute
@@ -83,6 +91,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/characters': typeof CharactersRoute
+  '/fal': typeof FalRoute
   '/locations': typeof LocationsRoute
   '/settings': typeof SettingsRoute
   '/storyboard': typeof StoryboardRoute
@@ -95,6 +104,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/characters'
+    | '/fal'
     | '/locations'
     | '/settings'
     | '/storyboard'
@@ -105,6 +115,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/characters'
+    | '/fal'
     | '/locations'
     | '/settings'
     | '/storyboard'
@@ -115,6 +126,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/characters'
+    | '/fal'
     | '/locations'
     | '/settings'
     | '/storyboard'
@@ -126,6 +138,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   CharactersRoute: typeof CharactersRoute
+  FalRoute: typeof FalRoute
   LocationsRoute: typeof LocationsRoute
   SettingsRoute: typeof SettingsRoute
   StoryboardRoute: typeof StoryboardRoute
@@ -155,6 +168,13 @@ declare module '@tanstack/react-router' {
       path: '/locations'
       fullPath: '/locations'
       preLoaderRoute: typeof LocationsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/fal': {
+      id: '/fal'
+      path: '/fal'
+      fullPath: '/fal'
+      preLoaderRoute: typeof FalRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/characters': {
@@ -198,6 +218,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   CharactersRoute: CharactersRoute,
+  FalRoute: FalRoute,
   LocationsRoute: LocationsRoute,
   SettingsRoute: SettingsRoute,
   StoryboardRoute: StoryboardRoute,

--- a/src/routes/fal.tsx
+++ b/src/routes/fal.tsx
@@ -1,0 +1,152 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { useState } from 'react'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { fal } from '@fal-ai/client'
+
+interface ModelOption {
+  id: string
+  label: string
+  supportsImage: boolean
+  aspectRatios?: string[]
+}
+
+const models: ModelOption[] = [
+  { id: 'fal-ai/kontext-pro', label: 'Kontext Pro', supportsImage: false },
+  { id: 'fal-ai/fast-flux', label: 'Fast FLUX', supportsImage: true, aspectRatios: ['1:1', '16:9', '9:16'] },
+]
+
+export const Route = createFileRoute('/fal')({
+  component: FalPage,
+})
+
+function FalPage() {
+  const [modelId, setModelId] = useState(models[0].id)
+  const model = models.find((m) => m.id === modelId)!
+  const [prompt, setPrompt] = useState('')
+  const [imageFile, setImageFile] = useState<File | null>(null)
+  const [aspect, setAspect] = useState(model.aspectRatios ? model.aspectRatios[0] : '')
+  const [resultUrl, setResultUrl] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    fal.config({ credentials: import.meta.env.VITE_FAL_KEY as string })
+    try {
+      const input: any = { prompt }
+      if (model.supportsImage && imageFile) {
+        input.image_url = await fileToDataUrl(imageFile)
+      }
+      if (model.aspectRatios) {
+        input.aspect_ratio = aspect
+      }
+      const { data } = await fal.run(model.id, { input })
+      if (data && (data.image_url || data.output)) {
+        setResultUrl(data.image_url ?? data.output)
+      }
+    } catch (err) {
+      console.error(err)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold">fal.ai Playground</h1>
+        <p className="text-muted-foreground mt-1">Generate media using fal.ai models</p>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Generation</CardTitle>
+          <CardDescription>Select a model and enter your prompt</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label>Model</Label>
+              <Select value={modelId} onValueChange={setModelId}>
+                <SelectTrigger id="model">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {models.map((m) => (
+                    <SelectItem key={m.id} value={m.id}>
+                      {m.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="prompt">Prompt</Label>
+              <Textarea
+                id="prompt"
+                value={prompt}
+                onChange={(e) => setPrompt(e.target.value)}
+                rows={4}
+              />
+            </div>
+
+            {model.supportsImage && (
+              <div className="space-y-2">
+                <Label htmlFor="image">Upload Image (optional)</Label>
+                <Input id="image" type="file" accept="image/*" onChange={(e) => setImageFile(e.target.files?.[0] || null)} />
+              </div>
+            )}
+
+            {model.aspectRatios && (
+              <div className="space-y-2">
+                <Label>Aspect Ratio</Label>
+                <Select value={aspect} onValueChange={setAspect}>
+                  <SelectTrigger id="aspect">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {model.aspectRatios.map((r) => (
+                      <SelectItem key={r} value={r}>
+                        {r}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+
+            <Button type="submit" disabled={loading} className="mt-2">
+              {loading ? 'Generating...' : 'Generate'}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+
+      {resultUrl && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Result</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <img src={resultUrl} alt="result" className="w-full rounded-md" />
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}
+
+function fileToDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result as string)
+    reader.onerror = reject
+    reader.readAsDataURL(file)
+  })
+}


### PR DESCRIPTION
## Summary
- install `@fal-ai/client`
- add new `/fal` page using fal.ai models
- include model dropdown, optional image upload, and aspect ratio options
- link new page in the site navigation

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_687c1eca20dc8323a14144fe3e2b1677