### PR TITLE
feat: use stored API keys with env fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 # Replace with your Convex deployment URL after running `npx convex init`
 VITE_CONVEX_URL=""
+# fal.ai API key used for image/video generation
+VITE_FAL_KEY=""

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Codex is an example storyboard and production tool built with **React 19**, **Ta
    npx convex dev
    cp .env.example .env
    # Edit .env and set VITE_CONVEX_URL to the URL printed by the command above
+   # Optionally set VITE_FAL_KEY to use fal.ai without configuring settings
    ```
 
 3. Generate Convex TypeScript bindings:

--- a/src/routes/fal.tsx
+++ b/src/routes/fal.tsx
@@ -7,6 +7,7 @@ import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { fal } from '@fal-ai/client'
+import { getApiKey } from '@/utils/settings'
 
 interface ModelOption {
   id: string
@@ -41,7 +42,7 @@ function FalPage() {
     setLoading(true)
     setError(null)
     setResultUrl(null)
-    fal.config({ credentials: import.meta.env.VITE_FAL_KEY as string })
+    fal.config({ credentials: getApiKey('falai') as string })
     try {
       const input: any = { prompt }
       if (model.supportsImage && imageFile) {

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -8,30 +8,17 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Save, TestTube, Key } from 'lucide-react'
 import { useState } from 'react'
 import type { GenerationSettings } from '@/types/storyboard'
+import { getStoredSettings, saveSettings } from '@/utils/settings'
 
 export const Route = createFileRoute('/settings')({
   component: SettingsPage,
 })
 
 function SettingsPage() {
-  const [settings, setSettings] = useState<GenerationSettings>({
-    mockMode: true,
-    apiKeys: {
-      openai: '',
-      anthropic: '',
-      elevenlabs: '',
-      falai: '',
-    },
-    defaultModels: {
-      chat: 'openai',
-      speech: 'elevenlabs',
-      image: 'falai',
-      video: 'falai',
-    },
-  })
+  const [settings, setSettings] = useState<GenerationSettings>(() => getStoredSettings())
 
   const handleSave = () => {
-    // In a real app, save to localStorage or backend
+    saveSettings(settings)
     console.log('Saving settings:', settings)
   }
 

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -1,0 +1,41 @@
+import type { GenerationSettings } from '@/types/storyboard'
+
+const DEFAULT_SETTINGS: GenerationSettings = {
+  mockMode: true,
+  apiKeys: {
+    openai: '',
+    anthropic: '',
+    elevenlabs: '',
+    falai: '',
+  },
+  defaultModels: {
+    chat: 'openai',
+    speech: 'elevenlabs',
+    image: 'falai',
+    video: 'falai',
+  },
+}
+
+const STORAGE_KEY = 'codex_settings'
+
+export function getStoredSettings(): GenerationSettings {
+  if (typeof localStorage === 'undefined') return DEFAULT_SETTINGS
+  const raw = localStorage.getItem(STORAGE_KEY)
+  if (!raw) return DEFAULT_SETTINGS
+  try {
+    return { ...DEFAULT_SETTINGS, ...JSON.parse(raw) }
+  } catch {
+    return DEFAULT_SETTINGS
+  }
+}
+
+export function saveSettings(settings: GenerationSettings) {
+  if (typeof localStorage === 'undefined') return
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(settings))
+}
+
+export function getApiKey(key: keyof GenerationSettings['apiKeys']): string | undefined {
+  const settings = getStoredSettings()
+  const envKey = `VITE_${key.toUpperCase()}_KEY`
+  return settings.apiKeys[key] || (import.meta.env as any)[envKey]
+}


### PR DESCRIPTION
## Summary
- persist settings to localStorage
- load settings on Settings page
- retrieve fal.ai key from stored settings with env fallback
- add helper functions for managing settings and api keys
- document optional `VITE_FAL_KEY` in README and `.env.example`

## Testing
- `pnpm install`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_687c2ca999388323b751070dca6b212e